### PR TITLE
Remove usage of o11yphant-trace-honeycomb

### DIFF
--- a/core-java/pom.xml
+++ b/core-java/pom.xml
@@ -48,16 +48,6 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-trace-honeycomb</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.undertow</groupId>
-          <artifactId>undertow-servlet</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-trace-otel</artifactId>
     </dependency>
     <dependency>

--- a/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
+++ b/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
@@ -82,12 +82,12 @@ public class ClientMetricManager
     {
         if ( this.configuration.isEnabled() )
         {
-            O11yphantTracePlugin<?> plugin = new OtelTracePlugin( configuration, configuration );
+            O11yphantTracePlugin plugin = new OtelTracePlugin( configuration, configuration );
             if ( StringUtils.isNotBlank( configuration.getGrpcEndpointUri() ) )
             {
                 plugin = new OtelTracePlugin( configuration, configuration );
             }
-            this.traceManager = new TraceManager<>( plugin, new SpanFieldsDecorator(
+            this.traceManager = new TraceManager( plugin, new SpanFieldsDecorator(
                     Collections.singletonList( new ClientGoldenSignalsSpanFieldsInjector( metricSet ) ) ),
                                                     configuration );
         }

--- a/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
+++ b/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
@@ -18,8 +18,6 @@ package org.commonjava.indy.client.core.metric;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.commonjava.indy.client.core.inject.ClientMetricSet;
-import org.commonjava.o11yphant.honeycomb.HoneycombConfiguration;
-import org.commonjava.o11yphant.honeycomb.HoneycombTracePlugin;
 import org.commonjava.o11yphant.otel.OtelConfiguration;
 import org.commonjava.o11yphant.otel.OtelTracePlugin;
 import org.commonjava.o11yphant.trace.SpanFieldsDecorator;
@@ -77,19 +75,14 @@ public class ClientMetricManager
             this.configuration.setGrpcHeaders( existedOtelConfig.getGrpcHeaders() );
             this.configuration.setGrpcResources( existedOtelConfig.getResources() );
         }
-        else if ( existedTraceConfig instanceof HoneycombConfiguration )
-        {
-            HoneycombConfiguration existedHoneyConfig = (HoneycombConfiguration) existedTraceConfig;
-            this.configuration.setWriteKey( existedHoneyConfig.getWriteKey() );
-            this.configuration.setDataset( existedHoneyConfig.getDataset() );
-        }
         buildTraceManager();
     }
-    private void buildTraceManager(){
+
+    private void buildTraceManager()
+    {
         if ( this.configuration.isEnabled() )
         {
-            O11yphantTracePlugin<?> plugin =
-                    new HoneycombTracePlugin( configuration, configuration, Optional.of( classifier ) );
+            O11yphantTracePlugin<?> plugin = new OtelTracePlugin( configuration, configuration );
             if ( StringUtils.isNotBlank( configuration.getGrpcEndpointUri() ) )
             {
                 plugin = new OtelTracePlugin( configuration, configuration );

--- a/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientTracerConfiguration.java
+++ b/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientTracerConfiguration.java
@@ -17,7 +17,6 @@ package org.commonjava.indy.client.core.metric;
 
 import org.apache.commons.lang3.StringUtils;
 import org.commonjava.indy.client.core.inject.ClientMetricConfig;
-import org.commonjava.o11yphant.honeycomb.HoneycombConfiguration;
 import org.commonjava.o11yphant.otel.OtelConfiguration;
 import org.commonjava.o11yphant.trace.TracerConfiguration;
 
@@ -28,7 +27,7 @@ import java.util.Set;
 @SuppressWarnings( "unused" )
 @ClientMetricConfig
 public class ClientTracerConfiguration
-        implements TracerConfiguration, OtelConfiguration, HoneycombConfiguration
+        implements TracerConfiguration, OtelConfiguration
 {
     private static final Integer DEFAULT_BASE_SAMPLE_RATE = 100;
 
@@ -76,18 +75,6 @@ public class ClientTracerConfiguration
     public boolean isConsoleTransport()
     {
         return consoleTransport;
-    }
-
-    @Override
-    public String getWriteKey()
-    {
-        return writeKey;
-    }
-
-    @Override
-    public String getDataset()
-    {
-        return dataset;
     }
 
     @Override
@@ -142,16 +129,6 @@ public class ClientTracerConfiguration
     public String getGrpcEndpointUri()
     {
         return grpcUri == null ? DEFAULT_GRPC_URI : grpcUri;
-    }
-
-    public void setDataset( String dataset )
-    {
-        this.dataset = dataset;
-    }
-
-    public void setWriteKey( String writeKey )
-    {
-        this.writeKey = writeKey;
     }
 
     public void setConsoleTransport( boolean consoleTransport )

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <jhttpcVersion>1.12</jhttpcVersion>
     <atlasVersion>1.1.1</atlasVersion>
 
-    <o11yphantVersion>1.8</o11yphantVersion>
+    <o11yphantVersion>1.9-SNAPSHOT</o11yphantVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <commonsioVersion>2.11.0</commonsioVersion>
@@ -134,11 +134,6 @@
       <dependency>
         <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace-api</artifactId>
-        <version>${o11yphantVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.util</groupId>
-        <artifactId>o11yphant-trace-honeycomb</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
As we start to use opentelemetry for tracing, the honeycomb native usage is deprecated and should be removed