### PR TITLE
Add promotion admin api deleteTrackingRecords

### DIFF
--- a/addons-client/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
+++ b/addons-client/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
@@ -31,7 +31,7 @@ public class IndyPromoteAdminClientModule
         extends IndyClientModule
 {
 
-    public static final String PROMOTE_ADMIN_BASEPATH = "admin/promotion";
+    public static final String PROMOTE_ADMIN_BASEPATH = "promotion/admin";
 
     public static final String VALIDATION_BASEPATH = PROMOTE_ADMIN_BASEPATH + "/validation";
 
@@ -56,6 +56,7 @@ public class IndyPromoteAdminClientModule
     public static final String VALIDATION_RULESET_GET_BY_STOREKEY_PATH = VALIDATION_RULESET_BASEPATH + "/storekey";
 
     public static final String VALIDATION_RULESET_GET_BY_NAME_PATH = VALIDATION_RULESET_BASEPATH + "/named";
+    private static final String TRACKING = "/tracking";
 
     public boolean reloadRules()
             throws IndyClientException
@@ -109,4 +110,11 @@ public class IndyPromoteAdminClientModule
     {
         return http.get( buildUrl( VALIDATION_RULESET_GET_BY_STOREKEY_PATH, key.toString() ), ValidationRuleSet.class );
     }
+
+    public void deleteTrackingRecords( final String trackingId )
+            throws IndyClientException
+    {
+        http.delete( buildUrl(TRACKING, trackingId ) );
+    }
+
 }


### PR DESCRIPTION
As subject. 
This is for [MMENG-3966](https://issues.redhat.com/browse/MMENG-3966) - Implement promotion-tracking DELETE endpoint
This pr also updated PROMOTE_ADMIN_BASEPATH. After moving to promotion service, it should be "promotion/admin", instead of "admin/promotion".