### PR TITLE
Revert "Make MetricsProducers default"

### DIFF
--- a/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricsProducer.java
+++ b/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricsProducer.java
@@ -15,39 +15,54 @@
  */
 package org.commonjava.indy.client.core.metric;
 
+import org.commonjava.cdi.util.weft.config.DefaultWeftConfig;
+import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.o11yphant.metrics.TrafficClassifier;
 import org.commonjava.o11yphant.metrics.conf.DefaultMetricsConfig;
 import org.commonjava.o11yphant.metrics.conf.MetricsConfig;
 import org.commonjava.o11yphant.metrics.sli.GoldenSignalsMetricSet;
 import org.commonjava.o11yphant.metrics.system.StoragePathProvider;
 
+import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Produces;
 
 /**
- * This producer is used to provide the missing CDI deps for indy client metrics sets. User can specify
- * customized producers with @Alternative to provide alternative functions.
+ * This producer is used to provide the missing CDI deps for indy client metrics sets. Now all
+ * produces provided alternative ones, because it will break indy metrics providers. In future the
+ * indy-client libs will be extracted to a single lib, so then we will set these providers as default.
  */
 public class ClientMetricsProducer
 {
     @Produces
+    @Alternative
     public TrafficClassifier getClientTrafficClassifier()
     {
         return new ClientTrafficClassifier();
     }
 
     @Produces
+    @Alternative
     public GoldenSignalsMetricSet getClientMetricSet()
     {
         return new ClientGoldenSignalsMetricSet();
     }
 
     @Produces
+    @Alternative
     public MetricsConfig getMetricsConfig()
     {
         return new DefaultMetricsConfig();
     }
 
     @Produces
+    @Alternative
+    public WeftConfig getWeftConfig()
+    {
+        return new DefaultWeftConfig();
+    }
+
+    @Produces
+    @Alternative
     public StoragePathProvider getStoragePathProvider()
     {
         return () -> null;

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <jhttpcVersion>1.12</jhttpcVersion>
     <atlasVersion>1.1.1</atlasVersion>
     <indyModelVersion>1.5</indyModelVersion>
-    <o11yphantVersion>1.9.2-SNAPSHOT</o11yphantVersion>
+    <o11yphantVersion>1.9.1</o11yphantVersion>
     <httpclientVersion>4.5.13</httpclientVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <commonsioVersion>2.11.0</commonsioVersion>


### PR DESCRIPTION
This reverts commit 9fa6dfd5408f7b9aeca54daaea02331cad4ebaa2.

Because PNC will not use this 3.3.x due to remaining CDI issues, and this commit will also break Indy builds, let's revert this commit to keep Indy can running. 
I'll create 3.4.0 branch for the o11yphant deps removal to resolve the CDI issues from bottom.